### PR TITLE
Fix 404 bug when UTF8 character is included in URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "bugs": "https://github.com/adlawson/mixcloud-tracklist/issues",
   "license": "MIT",
   "engines": {
-  	"node": ">=6.9.0"
+    "node": ">=6.9.0"
   },
   "dependencies": {
-  	"dustjs-linkedin": "~2.7.0",
+    "dustjs-linkedin": "~2.7.0",
     "request": "~2.78"
   },
   "devDependencies": {

--- a/tracklist.js
+++ b/tracklist.js
@@ -51,7 +51,7 @@ function fetchData(location, fn) {
     request({
         "uri": "/player/details",
         "baseUrl": location.protocol + "//" + location.hostname,
-        "qs": { "key": encodeURIComponent(location.pathname) },
+        "qs": { "key": location.pathname },
         "json": true
     }, (error, response, data) => {
         if (!error && response.statusCode === 200 && data.cloudcast.sections.length > 0) {


### PR DESCRIPTION
- A tracklist does not appear when a UTF-8 character is included in URL.
  - [Example](https://www.mixcloud.com/asonas/kosendj-bu-2016%E5%B9%B4%E3%82%82%E6%9C%80%E9%AB%98%E3%81%A0%E3%81%A3%E3%81%9F%E3%81%ADmix/)
- `request` module is using `qs` module for encoding params. `qs` returns URI encoded params, so this package sends an XHR request to mixcloud using double-encoded params. Thanks to mixcloud don't use special chars such as `#` to URL, an almost user didn't notice this bug.