### PR TITLE
Display track timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 #
 # Source
 # ------
-BUILD := manifest.json images/* build/mixcloud-tracklist.js
-SOURCE := manifest.json images/* templates/*.dust tracklist.js
+BUILD := manifest.json options.* images/* build/mixcloud-tracklist.js
+SOURCE := manifest.json options.* images/* templates/*.dust tracklist.js
 
 
 # Executable path

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,13 @@
       "strict_min_version": "45.0"
     }
   },
+  "permissions": [
+    "storage"
+  ],
+  "options_ui": {
+    "page": "options.html",
+    "chrome_style": true
+  },
   "content_scripts": [
     {
       "matches": ["*://*.mixcloud.com/*"],

--- a/options.html
+++ b/options.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mixcloud Tracklist - Options</title>
+    <style>
+        .disabled {
+          color: #999;
+        }
+        .input-container {
+            padding: 5px;
+        }
+        label small {
+          display: block;
+          margin-left: 18px;
+          padding-top: 5px;
+        }
+    </style>
+</head>
+
+<body>
+
+    <p></p>
+
+    <form>
+        <div class="input-container">
+            <label class="disabled">
+                <input type="checkbox" name="feature.core" checked disabled/>
+                <strong>Core tracklist functionality</strong>
+                <small>Replace the missing tracklist</small>
+            </label>
+        </div>
+        <div class="input-container">
+            <label>
+                <input type="checkbox" name="feature.timestamp" id="timestamp"/>
+                <strong>Track timestamps</strong>
+                <small>Display timings of each track, if available, in the tracklist</small>
+            </label>
+        </div>
+        <div class="input-container">
+            <button id="save">Save changes</button>
+        </div>
+    </form>
+
+    <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,19 @@
+function save_options() {
+  var timestamp = document.getElementById('timestamp').checked;
+  chrome.storage.sync.set({
+    timestamp: timestamp
+  }, function () {
+    window.close();
+  });
+}
+
+function restore_options() {
+  chrome.storage.sync.get({
+    timestamp: false
+  }, function (items) {
+    document.getElementById('timestamp').checked = items.timestamp;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click', save_options);

--- a/templates/tracklist.dust
+++ b/templates/tracklist.dust
@@ -5,7 +5,7 @@
             <ul class="show-tracklist" ng-init="tracklistShown=false;audioLength={audio_length};sectionStartTimes=[]">
                 {#sections}
                     <li ng-hide="juno.sections.length">
-                        <em>{track_number}</em>
+                        {?timestamp}<em style="width:40px;">{timestamp}</em>{:else}<em>{track_number}</em>{/timestamp}
                         {?chapter}<b title="{chapter}">{chapter}</b>{:else}<b title="{title}">{title}</b>{/chapter}
                         {?artist}<small> by <span>{artist}</span></small>{/artist}
                     </li>

--- a/tracklist.js
+++ b/tracklist.js
@@ -48,16 +48,20 @@ function fetchData(location, fn) {
         "json": true
     }, (error, response, data) => {
         if (!error && response.statusCode === 200 && data.cloudcast.sections.length > 0) {
-            fn(insertTimestamp(insertTrackNumber(data)));
+            chrome.storage.sync.get({
+              timestamp: false
+            }, (options) => {
+                fn(insertTimestamp(insertTrackNumber(data), options));
+            });
         } else {
             console.error(error);
         }
     });
 }
 
-function insertTimestamp(data) {
+function insertTimestamp(data, options) {
     data.cloudcast.sections.forEach((section, i) => {
-        if (section.start_time !== null) {
+        if (section.start_time !== null && options.timestamp === true) {
             const minutes = Math.floor(section.start_time / 60);
             const seconds = ("0" + section.start_time % 60).slice(-2);
             section.timestamp = `${minutes}:${seconds}`;

--- a/tracklist.js
+++ b/tracklist.js
@@ -48,11 +48,24 @@ function fetchData(location, fn) {
         "json": true
     }, (error, response, data) => {
         if (!error && response.statusCode === 200 && data.cloudcast.sections.length > 0) {
-            fn(insertTrackNumber(data));
+            fn(insertTimestamp(insertTrackNumber(data)));
         } else {
             console.error(error);
         }
     });
+}
+
+function insertTimestamp(data) {
+    data.cloudcast.sections.forEach((section, i) => {
+        if (section.start_time !== null) {
+            const minutes = Math.floor(section.start_time / 60);
+            const seconds = ("0" + section.start_time % 60).slice(-2);
+            section.timestamp = `${minutes}:${seconds}`;
+        } else {
+          section.timestamp = null;
+        }
+    });
+    return data;
 }
 
 function insertTrackNumber(data) {


### PR DESCRIPTION
These changes add track timings to the tracklist.

It also includes an options page to enable the feature (disabled by default).
When enabled, the start time is shown instead of the track number. If disabled or timings aren't available, the track number is shown just like before.

This needs some further testing before merged and released.
 - [x] Chrome extension
 - [ ] Firefox addon
 - [ ] Tampermonkey userscript

Resolves #11, #6.

---

![image](https://cloud.githubusercontent.com/assets/200351/24837123/e13819a2-1d24-11e7-9616-5b57b7b2d6f4.png)

---

![image](https://cloud.githubusercontent.com/assets/200351/24837151/34fdfb56-1d25-11e7-97c8-42ed013fdd29.png)
