### PR TITLE
Send cookies with API request

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   },
   "dependencies": {
     "dustjs-linkedin": "~2.7.0",
-    "request": "~2.78"
+    "promise-polyfill": "^6.0.2",
+    "url-polyfill": "^1.0.7",
+    "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",

--- a/tracklist.js
+++ b/tracklist.js
@@ -11,8 +11,11 @@
 
 'use strict';
 
+require('whatwg-fetch'); // Patches window.fetch
+require('url-polyfill'); // Patches window.URL
+
 const dust = require('dustjs-linkedin');
-const request = require('request');
+const Promise = require('promise-polyfill');
 const browser = require('./browser');
 
 main();
@@ -41,18 +44,21 @@ function main() {
 }
 
 function fetchData(location, fn) {
-    request({
-        "uri": "/player/details",
-        "baseUrl": location.protocol + "//" + location.hostname,
-        "qs": { "key": location.pathname },
-        "json": true
-    }, (error, response, data) => {
-        if (!error && response.statusCode === 200 && data.cloudcast.sections.length > 0) {
-            fn(insertTrackNumber(data));
-        } else {
-            console.error(error);
-        }
-    });
+  let url = new URL(`${location.protocol}//${location.hostname}/player/details/`);
+  url.searchParams.append('key', location.pathname);
+  fetch(url, { credentials: 'include' })
+    .then(rejectFailed)
+    .then(response => response.json())
+    .then(data => fn(insertTrackNumber(data)))
+    .catch(err => console.error('Request failed', err));
+}
+
+function rejectFailed(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return Promise.resolve(response);
+  } else {
+    return Promise.reject(new Error(response.statusText));
+  }
 }
 
 function insertTrackNumber(data) {

--- a/tracklist.js
+++ b/tracklist.js
@@ -49,8 +49,17 @@ function fetchData(location, fn) {
   fetch(url, { credentials: 'include' })
     .then(rejectFailed)
     .then(response => response.json())
+    .then(rejectEmpty)
     .then(data => fn(insertTrackNumber(data)))
-    .catch(err => console.error('Request failed', err));
+    .catch(err => console.warn("Tracklist unavailable", err));
+}
+
+function rejectEmpty(data) {
+  if (data.cloudcast.sections.length > 0) {
+    return Promise.resolve(data);
+  } else {
+    return Promise.reject(new ReferenceError("No tracklist returned"));
+  }
 }
 
 function rejectFailed(response) {


### PR DESCRIPTION
Mixcloud have integrated a CSRF token into their API, which strips out parts of the response if the value is missing or incorrect. These changes forward the browser cookies, which include the CSRF token, with the API request for the track list.

Also swaps `request` library for `window.fetch`, reducing the extension size substantially. Polyfills are included for browsers not supporting `fetch`, `Promise`, and `URL`.

Resolves #32.

---

These changes _will_ be released normally through the various web stores, but if you'd like to test it in the mean time (instructions for Chrome only):

1) Clone this repo, checkout `adlawson/csrf-cookie` and run:
```
npm install && make
```

2) Disable any other versions of this extension
![](https://cloud.githubusercontent.com/assets/200351/20079762/1d30cf30-a53e-11e6-8bd2-38cb813861a3.png)

3) Enable Developer mode at the top of the extensions settings page
![](https://cloud.githubusercontent.com/assets/200351/20079899/d82c6c72-a53e-11e6-84c7-ebd20d3cf4cf.png)

4) Click "Load unpacked extension" and open the project root
![](https://cloud.githubusercontent.com/assets/200351/20079911/e65fce7e-a53e-11e6-959c-dd44aeadc597.png)

Screenshots are taken from a previous release, so the version number will be different.